### PR TITLE
画面xml作成

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,13 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="app/src/main/res/layout/activity_main.xml" value="0.2078125" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_create_quiz.xml" value="0.335" />
+        <entry key="app/src/main/res/layout/fragment_select.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/fragment_show_all_quiz.xml" value="0.221875" />
+        <entry key="app/src/main/res/layout/fragment_top.xml" value="0.165" />
+        <entry key="app/src/main/res/layout/select_fragment.xml" value="0.221875" />
+        <entry key="app/src/main/res/layout/show_all_quiz.xml" value="0.221875" />
       </map>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'androidx.navigation.safeargs.kotlin'
 }
 
 android {
@@ -29,6 +31,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    viewBinding {
+        enabled = true
+    }
+    buildFeatures {
+        dataBinding true
+    }
 }
 
 dependencies {
@@ -40,4 +48,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
 }

--- a/app/src/main/java/com/example/quizapp/MainActivity.kt
+++ b/app/src/main/java/com/example/quizapp/MainActivity.kt
@@ -2,10 +2,16 @@ package com.example.quizapp
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Button
+import com.example.quizapp.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding : ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         setContentView(R.layout.activity_main)
     }
 }

--- a/app/src/main/java/com/example/quizapp/fragment/CreateQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/CreateQuizFragment.kt
@@ -36,4 +36,8 @@ class CreateQuizFragment : Fragment() {
             findNavController().navigate(R.id.action_topFragment_to_selectFragment)
         }
     }
+    override fun onDestroyView(){
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/example/quizapp/fragment/CreateQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/CreateQuizFragment.kt
@@ -1,0 +1,39 @@
+package com.example.quizapp.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.example.quizapp.R
+import com.example.quizapp.databinding.FragmentCreateQuizBinding
+
+class CreateQuizFragment : Fragment() {
+
+    private var _binding: FragmentCreateQuizBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        //val view = inflater.inflate(R.layout.fragment_top, container, false)
+
+        _binding = FragmentCreateQuizBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.createQuizButton.setOnClickListener {
+            findNavController().navigate(R.id.action_topFragment_to_selectFragment)
+        }
+    }
+}

--- a/app/src/main/java/com/example/quizapp/fragment/SelectFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/SelectFragment.kt
@@ -7,18 +7,11 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.quizapp.R
-import com.example.quizapp.databinding.FragmentTopBinding
-import com.google.api.client.extensions.android.http.AndroidHttp
-import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.sheets.v4.Sheets
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import com.example.quizapp.databinding.FragmentSelectBinding
 
-class TopFragment : Fragment() {
+class SelectFragment : Fragment() {
 
-    private var _binding: FragmentTopBinding? = null
+    private var _binding: FragmentSelectBinding? = null
     private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,22 +23,15 @@ class TopFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentTopBinding.inflate(inflater, container, false)
+        _binding = FragmentSelectBinding.inflate(inflater, container, false)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        //クイズボタン
-        binding.topQuizButton.setOnClickListener {
+        binding.quizStartButton.setOnClickListener {
             findNavController().navigate(R.id.action_topFragment_to_selectFragment)
-        }
-        //問題作成ボタン
-        binding.topCreateQuizButton.setOnClickListener {
-
-
-            findNavController().navigate(R.id.action_topFragment_to_createQuiz)
         }
     }
 

--- a/app/src/main/java/com/example/quizapp/fragment/ShowAllQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/ShowAllQuizFragment.kt
@@ -1,0 +1,40 @@
+package com.example.quizapp.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.quizapp.R
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [ShowAllQuizFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class ShowAllQuizFragment : Fragment() {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_show_all_quiz, container, false)
+    }
+}

--- a/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
@@ -1,0 +1,43 @@
+package com.example.quizapp.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.example.quizapp.R
+import com.example.quizapp.databinding.FragmentTopBinding
+
+class TopFragment : Fragment() {
+
+    private var _binding: FragmentTopBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentTopBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        //クイズボタン
+        binding.topQuizButton.setOnClickListener {
+            findNavController().navigate(R.id.action_topFragment_to_selectFragment)
+        }
+        //問題作成ボタン
+        binding.topCreateQuizButton.setOnClickListener {
+            findNavController().navigate(R.id.action_topFragment_to_createQuiz)
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
@@ -43,8 +43,6 @@ class TopFragment : Fragment() {
         }
         //問題作成ボタン
         binding.topCreateQuizButton.setOnClickListener {
-
-
             findNavController().navigate(R.id.action_topFragment_to_createQuiz)
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,12 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/main_nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_create_quiz.xml
+++ b/app/src/main/res/layout/fragment_create_quiz.xml
@@ -4,13 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="fragment.CreateQuiz">
+    tools:context="fragment.CreateQuizFragment">
 
     <TextView
         android:id="@+id/create_quiz_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30sp"
+        android:layout_marginTop="30dp"
         android:text="@string/createQuiz"
         android:textSize="25sp"
         app:layout_constraintEnd_toEndOf="parent"
@@ -30,10 +30,11 @@
 
     <EditText
         android:id="@+id/input_question_edit_text"
-        android:layout_width="200sp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_question"
         android:inputType="text"
+        android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@id/input_answer_edit_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/create_quiz_text" />
@@ -51,10 +52,11 @@
 
     <EditText
         android:id="@+id/input_answer_edit_text"
-        android:layout_width="200sp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_answer"
         android:inputType="text"
+        android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/input_fake_1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/input_question_edit_text" />
@@ -73,29 +75,32 @@
 
     <EditText
         android:id="@+id/input_fake_1"
-        android:layout_width="200sp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_fake1"
         android:inputType="text"
+        android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/create_quiz_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/input_answer_edit_text" />
 
     <EditText
         android:id="@+id/input_fake_2"
-        android:layout_width="200sp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_fake2"
         android:inputType="text"
+        android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/input_fake_1" />
 
     <EditText
         android:id="@+id/input_fake_3"
-        android:layout_width="200sp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
         android:hint="@string/hint_fake3"
         android:inputType="text"
+        android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/input_fake_2" />
 
@@ -108,6 +113,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/input_fake_text" />
+        app:layout_constraintTop_toBottomOf="@id/input_fake_3" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_create_quiz.xml
+++ b/app/src/main/res/layout/fragment_create_quiz.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="fragment.CreateQuiz">
+
+    <TextView
+        android:id="@+id/create_quiz_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30sp"
+        android:text="@string/createQuiz"
+        android:textSize="25sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/input_question_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/question"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toTopOf="@+id/input_answer_text"
+        app:layout_constraintEnd_toStartOf="@+id/input_question_edit_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/create_quiz_text" />
+
+    <EditText
+        android:id="@+id/input_question_edit_text"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_question"
+        android:inputType="text"
+        app:layout_constraintBottom_toTopOf="@id/input_answer_edit_text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/create_quiz_text" />
+
+    <TextView
+        android:id="@+id/input_answer_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/answer"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toTopOf="@+id/input_fake_text"
+        app:layout_constraintEnd_toStartOf="@+id/input_answer_edit_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_question_text" />
+
+    <EditText
+        android:id="@+id/input_answer_edit_text"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_answer"
+        android:inputType="text"
+        app:layout_constraintBottom_toTopOf="@+id/input_fake_1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_question_edit_text" />
+
+    <TextView
+        android:id="@+id/input_fake_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/fake_answer"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toTopOf="@id/create_quiz_button"
+        app:layout_constraintEnd_toStartOf="@+id/input_fake_1"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_answer_text" />
+
+    <EditText
+        android:id="@+id/input_fake_1"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_fake1"
+        android:inputType="text"
+        app:layout_constraintBottom_toTopOf="@+id/create_quiz_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_answer_edit_text" />
+
+    <EditText
+        android:id="@+id/input_fake_2"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_fake2"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_fake_1" />
+
+    <EditText
+        android:id="@+id/input_fake_3"
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:hint="@string/hint_fake3"
+        android:inputType="text"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/input_fake_2" />
+
+    <Button
+        android:id="@+id/create_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/createQuiz"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/input_fake_text" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_select.xml
+++ b/app/src/main/res/layout/fragment_select.xml
@@ -10,7 +10,7 @@
         android:id="@+id/select_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30sp"
+        android:layout_marginTop="30dp"
         android:text="@string/select_number_question"
         android:textSize="25sp"
         app:layout_constraintEnd_toEndOf="parent"
@@ -21,7 +21,6 @@
         android:id="@+id/radio_question"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="10sp"
         app:layout_constraintBottom_toTopOf="@+id/quiz_start_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -56,4 +55,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_select.xml
+++ b/app/src/main/res/layout/fragment_select.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="fragment.SelectFragment">
+
+    <TextView
+        android:id="@+id/select_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30sp"
+        android:text="@string/select_number_question"
+        android:textSize="25sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <RadioGroup
+        android:id="@+id/radio_question"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10sp"
+        app:layout_constraintBottom_toTopOf="@+id/quiz_start_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/select_text">
+
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/question1"
+            android:textSize="20sp" />
+
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/question5"
+            android:textSize="20sp" />
+
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/question10"
+            android:textSize="20sp" />
+    </RadioGroup>
+
+    <Button
+        android:id="@+id/quiz_start_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/QuizStart"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_top.xml
+++ b/app/src/main/res/layout/fragment_top.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="fragment.TopFragment">
+
+    <TextView
+        android:id="@+id/top"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30sp"
+        android:text="@string/top_text"
+        android:textSize="30sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/top_create_quiz"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/createQuiz"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/top_quiz"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top" />
+
+    <Button
+        android:id="@+id/top_quiz"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/quiz"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/top_create_quiz"
+        app:layout_constraintTop_toBottomOf="@id/top" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_top.xml
+++ b/app/src/main/res/layout/fragment_top.xml
@@ -10,7 +10,7 @@
         android:id="@+id/top"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="30sp"
+        android:layout_marginTop="30dp"
         android:text="@string/top_text"
         android:textSize="30sp"
         app:layout_constraintEnd_toEndOf="parent"
@@ -18,18 +18,18 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:id="@+id/top_create_quiz"
+        android:id="@+id/top_create_quiz_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/createQuiz"
         android:textSize="20sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/top_quiz"
+        app:layout_constraintEnd_toStartOf="@+id/top_quiz_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/top" />
 
     <Button
-        android:id="@+id/top_quiz"
+        android:id="@+id/top_quiz_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/quiz"
@@ -37,6 +37,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@+id/top_create_quiz"
+        app:layout_constraintStart_toEndOf="@+id/top_create_quiz_button"
         app:layout_constraintTop_toBottomOf="@id/top" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/topFragment">
+
+    <fragment
+        android:id="@+id/topFragment"
+        android:name="com.example.quizapp.fragment.TopFragment"
+        android:label="TopFragment"
+        tools:layout="@layout/fragment_top">
+        <action
+            android:id="@+id/action_topFragment_to_selectFragment"
+            app:destination="@id/selectFragment" />
+        <action
+            android:id="@+id/action_topFragment_to_createQuiz"
+            app:destination="@id/createQuizFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/selectFragment"
+        android:name="com.example.quizapp.fragment.SelectFragment"
+        android:label="SelectFragment"
+        tools:layout="@layout/fragment_select" />
+    <fragment
+        android:id="@+id/createQuizFragment"
+        android:name="com.example.quizapp.fragment.CreateQuizFragment"
+        android:label="CreateQuiz"
+        tools:layout="@layout/fragment_create_quiz" />
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,21 @@
 <resources>
     <string name="app_name">QuizApp</string>
+    <string name="quiz">クイズ</string>
+    <string name="answer">解答</string>
+    <string name="createQuiz">問題作成</string>
+    <string name="QuizStart">クイズ開始</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="question1">1問</string>
+    <string name="question5">5問</string>
+    <string name="question10">10問</string>
+    <string name="question">問題</string>
+    <string name="hint_question">ここに書いてね</string>
+    <string name="fake_answer">フェイクの答え</string>
+    <string name="hint_answer">正解を書いてね</string>
+    <string name="hint_fake1">偽物の答え1</string>
+    <string name="hint_fake2">偽物の答え2</string>
+    <string name="hint_fake3">偽物の答え3</string>
+    <string name="select_number_question">問題数を選択してください</string>
+    <string name="top_text">TOP</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,9 +13,9 @@
     <string name="hint_question">ここに書いてね</string>
     <string name="fake_answer">フェイクの答え</string>
     <string name="hint_answer">正解を書いてね</string>
-    <string name="hint_fake1">偽物の答え1</string>
-    <string name="hint_fake2">偽物の答え2</string>
-    <string name="hint_fake3">偽物の答え3</string>
+    <string name="hint_fake1">フェイク1</string>
+    <string name="hint_fake2">フェイク2</string>
+    <string name="hint_fake3">フェイク3</string>
     <string name="select_number_question">問題数を選択してください</string>
     <string name="top_text">TOP</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript{
+    repositories {
+        google()
+    }
+    dependencies {
+        def nav_version = "2.5.1"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
+    }
+}// Top-level build file where you can add configuration options common to all sub-projects/modules.
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '7.2.2' apply false


### PR DESCRIPTION
#### PR対応内容
・アプリを立ち上げトップ画面を表示する
・トップ画面にボタンを二つ追加
・選択画面を作成（遷移は未実装）
・問題作成画面を作成（遷移は未実装）
（本来遷移する問題一覧画面はAPI実装が必要の為、練習で問題作成画面に遷移するようにこれから実装します。）
#### 動作確認内容
・アプリがビルドできること
・アプリ立ち上げの際にトップ画面、選択画面、問題作成画面をそれぞれ表示させるように
書き換えて実施し、全ての画面が問題なく表示される

#### 仕様について

[参照リンク]
[Quiz App仕様](https://docs.google.com/document/d/1fSmP6zCMaYX_MuE9MSe2B3YiYSpgfkZ6YbwqfpG8gGo/edit)

[画像]
**TOP画面**
<img width="200" alt="TOP画面" src="https://user-images.githubusercontent.com/113078778/195303685-d0c43851-e262-4666-8aad-df4b01a33541.png">

**選択画面**
<img width="200" alt="選択画面" src="https://user-images.githubusercontent.com/113078778/195303696-0e675cf3-fe10-4edb-9a2f-d7a13151fda1.png">

**問題作成画面**
<img width="200" alt="問題作成画面" src="https://user-images.githubusercontent.com/113078778/195303709-be4d4551-a5b4-4dd0-85a3-d99f5fb2ea8b.png">
