### PR TITLE
API接続でspread sheetから問題取得

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,11 +3,13 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../Library/Android/sdk/platforms/android-32/data/res/layout/simple_list_item_1.xml" value="0.1" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.1" />
-        <entry key="app/src/main/res/layout/fragment_create_quiz.xml" value="0.335" />
+        <entry key="app/src/main/res/layout/fragment_create_quiz.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_select.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/fragment_show_all_quiz.xml" value="0.221875" />
-        <entry key="app/src/main/res/layout/fragment_top.xml" value="0.165" />
+        <entry key="app/src/main/res/layout/fragment_show_all.xml" value="0.14596554850407978" />
+        <entry key="app/src/main/res/layout/fragment_show_all_quiz.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_top.xml" value="0.1" />
         <entry key="app/src/main/res/layout/select_fragment.xml" value="0.221875" />
         <entry key="app/src/main/res/layout/show_all_quiz.xml" value="0.221875" />
       </map>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,9 @@ android {
     buildFeatures {
         dataBinding true
     }
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+    }
 }
 
 dependencies {
@@ -50,4 +53,19 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
+
+    implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
+
+    //spreadsheet
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev516-1.23.0'
+    implementation 'com.google.api-client:google-api-client-android:1.28.0'
+    implementation 'com.google.android.gms:play-services-auth:20.3.0'
+
+    // coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+
+    // retrofit
+    def retrofitVersion = '2.9.0'
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.quizapp">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/quizapp/SpreadSheets.kt
+++ b/app/src/main/java/com/example/quizapp/SpreadSheets.kt
@@ -1,0 +1,21 @@
+package com.example.quizapp
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+const val base_url = "https://sheets.googleapis.com/v4/spreadsheets/"
+const val spread_name = "Quiz"
+const val spread_id = "1ZETSrcwwOCdP_wP_s9xd9NtRNKh2M4DgsIUenJFTDAM"
+const val api_key = "AIzaSyAmRdJDJCqMKnV8F82XGcziNFCVYcsGtco"
+
+interface SpreadSheets {
+    @GET("{spread_id}/values/{spread_name}")
+
+    fun getQuiz(
+        @Path("spread_id") spreadId: String = spread_id,
+        @Path("spread_name") spreadName: String = spread_name,
+        @Query("key") query: String = api_key
+    ): Call<SpreadSheetsData>
+}

--- a/app/src/main/java/com/example/quizapp/SpreadSheetsData.kt
+++ b/app/src/main/java/com/example/quizapp/SpreadSheetsData.kt
@@ -1,0 +1,7 @@
+package com.example.quizapp
+
+data class SpreadSheetsData(
+    val majorDimension: String,
+    val range: String,
+    val values: List<List<String>>
+)

--- a/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
+++ b/app/src/main/java/com/example/quizapp/fragment/TopFragment.kt
@@ -8,13 +8,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.quizapp.R
 import com.example.quizapp.databinding.FragmentTopBinding
-import com.google.api.client.extensions.android.http.AndroidHttp
-import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.sheets.v4.Sheets
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class TopFragment : Fragment() {
 
@@ -43,7 +36,7 @@ class TopFragment : Fragment() {
         }
         //問題作成ボタン
         binding.topCreateQuizButton.setOnClickListener {
-            findNavController().navigate(R.id.action_topFragment_to_createQuiz)
+            findNavController().navigate(R.id.action_topFragment_to_showAllQuizFragment)
         }
     }
 

--- a/app/src/main/res/layout/fragment_show_all_quiz.xml
+++ b/app/src/main/res/layout/fragment_show_all_quiz.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragment.ShowAllQuizFragment">
+
+    <TextView
+        android:id="@+id/all_quiz_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="30dp"
+        android:text="@string/all_quiz"
+        android:textSize="30sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ListView
+        android:id="@+id/show_all_quiz_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/show_all_create_quiz_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/all_quiz_text" />
+
+    <Button
+        android:id="@+id/show_all_create_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/createQuiz"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/show_all_quiz_list" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -13,9 +13,10 @@
         <action
             android:id="@+id/action_topFragment_to_selectFragment"
             app:destination="@id/selectFragment" />
+
         <action
-            android:id="@+id/action_topFragment_to_createQuiz"
-            app:destination="@id/createQuizFragment" />
+            android:id="@+id/action_topFragment_to_showAllQuizFragment"
+            app:destination="@id/showAllQuizFragment" />
     </fragment>
 
     <fragment
@@ -26,6 +27,15 @@
     <fragment
         android:id="@+id/createQuizFragment"
         android:name="com.example.quizapp.fragment.CreateQuizFragment"
-        android:label="CreateQuiz"
+        android:label="CreateQuizFragment"
         tools:layout="@layout/fragment_create_quiz" />
+    <fragment
+        android:id="@+id/showAllQuizFragment"
+        android:name="com.example.quizapp.fragment.ShowAllQuizFragment"
+        android:label="ShowAllQuizFragment"
+        tools:layout="@layout/fragment_show_all_quiz">
+        <action
+            android:id="@+id/action_showAllQuizFragment_to_createQuizFragment"
+            app:destination="@id/createQuizFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="hint_fake3">フェイク3</string>
     <string name="select_number_question">問題数を選択してください</string>
     <string name="top_text">TOP</string>
+    <string name="all_quiz">問題一覧</string>
 </resources>


### PR DESCRIPTION
#### PR対応内容
・トップ画面の問題作成をタップで問題一覧画面に遷移
・問題一覧画面でspread sheetsから取得した問題を表示
・問題一覧画面の問題作成をタップで問題作成画面に遷移

#### 動作確認内容
・アプリがビルドできること
・ボタンタップ時にそれぞれ正しい画面に遷移する

#### 仕様について

[参照リンク]
[Quiz App仕様](https://docs.google.com/document/d/1fSmP6zCMaYX_MuE9MSe2B3YiYSpgfkZ6YbwqfpG8gGo/edit)
[spreadsheets](https://docs.google.com/spreadsheets/d/1ZETSrcwwOCdP_wP_s9xd9NtRNKh2M4DgsIUenJFTDAM/edit#gid=0)

[画像]
**TOP画面**
<img width="200" alt="TOP画面" src="https://user-images.githubusercontent.com/113078778/195303685-d0c43851-e262-4666-8aad-df4b01a33541.png">

**問題一覧画面**
<img width="200" alt="問題一覧画面" src="https://user-images.githubusercontent.com/113078778/198966682-ee875b01-1697-4a98-84bc-e8a1a3e07821.png">

